### PR TITLE
Posts Table RLS Policy Issue

### DIFF
--- a/supabase/migrations/20260116000007_fix_posts_rls.sql
+++ b/supabase/migrations/20260116000007_fix_posts_rls.sql
@@ -1,0 +1,27 @@
+-- Fix Posts RLS Policy Recursion Issue
+
+-- Create safe helper function
+CREATE OR REPLACE FUNCTION public.is_tribe_member(_tribe_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 FROM public.tribe_members 
+    WHERE tribe_id = _tribe_id AND user_id = auth.uid()
+  );
+END;
+$$;
+
+-- Drop problematic policies
+DROP POLICY IF EXISTS "Users can create posts in tribes they are members of" ON public.posts;
+
+-- Create fixed policy
+CREATE POLICY "Users can create posts in tribes they are members of" 
+ON public.posts FOR INSERT 
+WITH CHECK (
+  auth.uid() = user_id AND 
+  public.is_tribe_member(tribe_id)
+);


### PR DESCRIPTION
#3
Fixed. The issue was the INSERT policy was referencing tribe_id from the same table causing recursion. Now it uses a safe helper function is_tribe_member() to check membership without circular references