### PR TITLE
Password visibility toggle not working on Login & Signup pages(issue #1)

### DIFF
--- a/apps/web/src/components/ui/PasswordInput.tsx
+++ b/apps/web/src/components/ui/PasswordInput.tsx
@@ -1,0 +1,105 @@
+import { useState, useRef } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import clsx from 'clsx';
+
+interface PasswordInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    label?: string;
+    disabled?: boolean;
+    error?: string;
+    name?: string;
+    autoComplete?: string;
+    required?: boolean;
+    ariaLabel?: string;
+}
+
+export function PasswordInput({
+    value,
+    onChange,
+    placeholder = 'Password',
+    label,
+    disabled = false,
+    error,
+    name = 'password',
+    autoComplete = 'current-password',
+    required = true,
+    ariaLabel = 'Password',
+}: PasswordInputProps) {
+    const [showPassword, setShowPassword] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const togglePasswordVisibility = () => {
+        setShowPassword(!showPassword);
+        // Maintain focus after toggle
+        setTimeout(() => {
+            inputRef.current?.focus();
+        }, 0);
+    };
+
+    return (
+        <div className="w-full">
+            {label && (
+                <label className="block text-grey-400 text-sm mb-2 font-medium">
+                    {label}
+                </label>
+            )}
+            <div className="relative">
+                <input
+                    ref={inputRef}
+                    type={showPassword ? 'text' : 'password'}
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder={placeholder}
+                    name={name}
+                    autoComplete={autoComplete}
+                    required={required}
+                    disabled={disabled}
+                    aria-label={ariaLabel}
+                    aria-invalid={!!error}
+                    aria-describedby={error ? `${name}-error` : undefined}
+                    className={clsx(
+                        'w-full bg-charcoal-900 border text-white rounded-lg px-4 py-3 pr-12',
+                        'focus:outline-none focus:border-white/50 focus:ring-1 focus:ring-white/50',
+                        'placeholder-grey-600 transition-colors',
+                        'disabled:bg-charcoal-800 disabled:text-grey-500 disabled:cursor-not-allowed',
+                        error
+                            ? 'border-red-500'
+                            : 'border-charcoal-700'
+                    )}
+                />
+                <button
+                    type="button"
+                    onClick={togglePasswordVisibility}
+                    disabled={disabled}
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    aria-pressed={showPassword}
+                    title={showPassword ? 'Hide password' : 'Show password'}
+                    className={clsx(
+                        'absolute right-1 top-1/2 -translate-y-1/2 p-2 rounded-lg',
+                        'transition-colors',
+                        disabled
+                            ? 'opacity-50 cursor-not-allowed text-grey-500'
+                            : 'text-grey-500 hover:text-white hover:bg-charcoal-800'
+                    )}
+                >
+                    {showPassword ? (
+                        <Eye className="w-5 h-5" />
+                    ) : (
+                        <EyeOff className="w-5 h-5" />
+                    )}
+                </button>
+            </div>
+            {error && (
+                <div
+                    id={`${name}-error`}
+                    role="alert"
+                    className="block text-red-400 text-xs mt-1"
+                >
+                    {error}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import { PasswordInput } from '@/components/ui/PasswordInput';
 import { Globe } from '@/components/Globe';
 import logoDark from '@/components/assets/logo_dark.png';
 import googleIcon from '@/components/assets/playstore.svg';
@@ -103,14 +104,13 @@ export function LoginPage() {
 
                         {/* Password Input */}
                         <div className="mb-4">
-                            <label className="block text-grey-400 text-sm mb-2">Password</label>
-                            <input
-                                type="password"
+                            <PasswordInput
                                 value={password}
-                                onChange={(e) => setPassword(e.target.value)}
+                                onChange={setPassword}
+                                label="Password"
                                 placeholder="Enter your password"
-                                className="w-full bg-charcoal-900 border border-grey-800 text-white rounded-lg px-4 py-3 focus:outline-none focus:border-grey-600 transition-colors placeholder-grey-600"
-                                required
+                                disabled={emailLoading || loading}
+                                autoComplete="current-password"
                             />
                         </div>
 

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import { PasswordInput } from '@/components/ui/PasswordInput';
 import { Globe } from '@/components/Globe';
 import logoDark from '@/components/assets/logo_dark.png';
 import googleIcon from '@/components/assets/playstore.svg';
@@ -133,14 +134,13 @@ export function SignupPage() {
 
                         {/* Password Input */}
                         <div className="mb-6">
-                            <label className="block text-grey-400 text-sm mb-2">Password</label>
-                            <input
-                                type="password"
+                            <PasswordInput
                                 value={password}
-                                onChange={(e) => setPassword(e.target.value)}
+                                onChange={setPassword}
+                                label="Password"
                                 placeholder="Create a password"
-                                className="w-full bg-charcoal-900 border border-grey-800 text-white rounded-lg px-4 py-3 focus:outline-none focus:border-grey-600 transition-colors placeholder-grey-600"
-                                required
+                                disabled={signupLoading || loading}
+                                autoComplete="new-password"
                             />
                         </div>
 


### PR DESCRIPTION
The password input field on both **Login** and **Signup** pages does not allow users to toggle password visibility using an eye icon.

A reusable `PasswordInput` component was introduced to support this functionality, but the visibility toggle needs verification and alignment with the existing UI behavior.

### Expected Behavior
- Eye icon toggles password visibility (show / hide)
- Works consistently on Login and Signup pages
- Maintains accessibility and UI consistency

### Screenshots
<img width="1894" height="1020" alt="Screenshot 2026-01-22 184918" src="https://github.com/user-attachments/assets/c9963ae9-8d70-4782-a628-743276d86179" />
<img width="1892" height="1010" alt="Screenshot 2026-01-22 184933" src="https://github.com/user-attachments/assets/1930dfb9-f2c2-4115-9386-92785654f9b3" />

## Closes #1 