### PR TITLE
fix: dark mode styling on password autofill

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -100,3 +100,23 @@
     @apply bg-gradient-to-r from-white to-grey-100;
   }
 }
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover, 
+input:-webkit-autofill:focus, 
+input:-webkit-autofill:active,
+input:autofill,
+input:autofill:hover,
+input:autofill:focus,
+input:autofill:active {
+    /* Fix for Chrome/Safari/Edge */
+    -webkit-box-shadow: 0 0 0 30px #1a1a1a inset !important;
+    
+    /* Fix for Firefox & Future Standard */
+    box-shadow: 0 0 0 30px #1a1a1a inset !important;
+    
+    -webkit-text-fill-color: white !important;
+    color: white !important;
+    
+    transition: background-color 5000s ease-in-out 0s;
+}


### PR DESCRIPTION
Description:
Fixed an issue where browser autofill forced a white background on the password field, breaking the dark mode UI.

Changes:
Added a CSS override in `apps/web/src/index.css` so that the background color stays charcoal (#1a1a1a) when autofill is active.

Verified the build passes and the UI looks correct.
<img width="911" height="888" alt="Screenshot 2026-01-28 235250" src="https://github.com/user-attachments/assets/140b09c1-4ed5-451d-a8ca-638ba6c9d112" /> 
<img width="477" height="750" alt="image" src="https://github.com/user-attachments/assets/eb1a0727-d06c-4ece-a237-9c9bd197765f" />

Closes #35